### PR TITLE
Blur background image

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -103,6 +103,7 @@
     "html_options_suspend_force_screen_capture_tooltip_line5": { "message": "- Maximum height of screen capture limited to 5000px" },
     "html_options_suspend_force_screen_capture_tooltip_line6": { "message": "Enabling high quality screen capture mode may significantly increase CPU load" },
     "html_options_suspend_force_screen_capture_tooltip_line7": { "message": "and memory usage." },
+    "html_options_suspend_blur_screen_capture": { "message": "Blur preview image" },
     "html_options_whitelist_title": { "message": "Never suspend tabs with URLs from the following list:" },
     "html_options_whitelist_tooltip_line1": { "message": "Add the URL of each page you want to whitelist on a new line. For example:" },
     "html_options_whitelist_tooltip_line2": { "message": "To whitelist multiple sites in one line you can specify part of the url instead:" },

--- a/src/css/suspended.css
+++ b/src/css/suspended.css
@@ -91,9 +91,17 @@ body.suspended-page:not(.img-preview-mode) {
     top: 0;
     left: 0;
     padding: 30px 40px 20px;
-    width: 100%;
     text-align: center;
     z-index: 101;
+    margin: 80px;
+    -webkit-box-shadow: 0px 0px 10px 10px #fafafa;
+    -moz-box-shadow: 0px 0px 10px 10px #fafafa;
+    box-shadow: 0px 0px 10px 10px #fafafa;
+}
+.dark .gsTopBar {
+    -webkit-box-shadow: 0px 0px 10px 10px #222;
+    -moz-box-shadow: 0px 0px 10px 10px #222;
+    box-shadow: 0px 0px 10px 10px #222;
 }
 .faviconWrap {
     display: inline-block;
@@ -135,6 +143,14 @@ body.suspended-page:not(.img-preview-mode) {
     margin: 0 auto;
     padding: 30px 0;
 }
+.gsPreviewContainer.blurPreview {
+    position: absolute;
+    width: 100%;
+    top: 0;
+    left: 0;
+    padding: 0;
+    margin: 0px;
+}
 .gsPreviewImg {
     display: block;
     max-width: 100%;
@@ -144,12 +160,25 @@ body.suspended-page:not(.img-preview-mode) {
     box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
     transition: all 0.2s ease;
 }
+.blurPreview>.gsPreviewImg {
+    position: absolute;
+    min-width: calc(100% + 20px);
+    min-height: calc(100% + 20px);
+    left: -10px;
+    top: -10px;
+    margin: 0px;
+    border-radius: 0px;
+    filter: contrast(.5) brightness(0.8) blur(6px);
+}
 .gsPreviewImg:hover {
     box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
 }
 .dark .gsPreviewImg {
     filter: brightness(70%);
     opacity: 0.7;
+}
+.dark .blurPreview>.gsPreviewImg {
+    filter: contrast(.5) brightness(.5) blur(6px);
 }
 .dark .gsPreviewImg:hover {
     opacity: 1;

--- a/src/css/suspended.css
+++ b/src/css/suspended.css
@@ -91,17 +91,9 @@ body.suspended-page:not(.img-preview-mode) {
     top: 0;
     left: 0;
     padding: 30px 40px 20px;
+    width: 100%;
     text-align: center;
     z-index: 101;
-    margin: 80px;
-    -webkit-box-shadow: 0px 0px 10px 10px #fafafa;
-    -moz-box-shadow: 0px 0px 10px 10px #fafafa;
-    box-shadow: 0px 0px 10px 10px #fafafa;
-}
-.dark .gsTopBar {
-    -webkit-box-shadow: 0px 0px 10px 10px #222;
-    -moz-box-shadow: 0px 0px 10px 10px #222;
-    box-shadow: 0px 0px 10px 10px #222;
 }
 .faviconWrap {
     display: inline-block;
@@ -143,13 +135,20 @@ body.suspended-page:not(.img-preview-mode) {
     margin: 0 auto;
     padding: 30px 0;
 }
-.gsPreviewContainer.blurPreview {
+.gsPreviewContainer.blured {
     position: absolute;
-    width: 100%;
     top: 0;
+    bottom: 0;
     left: 0;
+    right: 0;
+    z-index: 0;
+    width: 100%;
     padding: 0;
-    margin: 0px;
+    overflow: hidden;
+    filter: contrast(.5) brightness(0.8) blur(6px);
+}
+.dark .gsPreviewContainer.blured {
+    filter: contrast(.5) brightness(0.5) blur(6px);
 }
 .gsPreviewImg {
     display: block;
@@ -160,25 +159,19 @@ body.suspended-page:not(.img-preview-mode) {
     box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
     transition: all 0.2s ease;
 }
-.blurPreview>.gsPreviewImg {
-    position: absolute;
-    min-width: calc(100% + 20px);
-    min-height: calc(100% + 20px);
-    left: -10px;
-    top: -10px;
-    margin: 0px;
-    border-radius: 0px;
-    filter: contrast(.5) brightness(0.8) blur(6px);
+.gsPreviewContainer.blured .gsPreviewImg {
+    width: 100%;
+    box-shadow: none;
 }
 .gsPreviewImg:hover {
     box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
 }
+.gsPreviewContainer.blured .gsPreviewImg:hover {
+    box-shadow: none;
+}
 .dark .gsPreviewImg {
     filter: brightness(70%);
     opacity: 0.7;
-}
-.dark .blurPreview>.gsPreviewImg {
-    filter: contrast(.5) brightness(.5) blur(6px);
 }
 .dark .gsPreviewImg:hover {
     opacity: 1;

--- a/src/js/gsStorage.js
+++ b/src/js/gsStorage.js
@@ -4,6 +4,7 @@
 var gsStorage = {
   SCREEN_CAPTURE: 'screenCapture',
   SCREEN_CAPTURE_FORCE: 'screenCaptureForce',
+  SCREEN_CAPTURE_BLUR: 'screenCaptureBlur',
   SUSPEND_IN_PLACE_OF_DISCARD: 'suspendInPlaceOfDiscard',
   UNSUSPEND_ON_FOCUS: 'gsUnsuspendOnFocus',
   SUSPEND_TIME: 'gsTimeToSuspend',
@@ -39,6 +40,7 @@ var gsStorage = {
     const defaults = {};
     defaults[gsStorage.SCREEN_CAPTURE] = '0';
     defaults[gsStorage.SCREEN_CAPTURE_FORCE] = false;
+    defaults[gsStorage.SCREEN_CAPTURE_BLUR] = false;
     defaults[gsStorage.SUSPEND_IN_PLACE_OF_DISCARD] = false;
     defaults[gsStorage.DISCARD_IN_PLACE_OF_SUSPEND] = false;
     defaults[gsStorage.USE_ALT_SCREEN_CAPTURE_LIB] = false;

--- a/src/js/gsSuspendedTab.js
+++ b/src/js/gsSuspendedTab.js
@@ -213,7 +213,7 @@ var gsSuspendedTab = (function() {
       const previewEl = _document.createElement('div');
       const bodyEl = _document.getElementsByTagName('body')[0];
       previewEl.setAttribute('id', 'gsPreviewContainer');
-      previewEl.classList.add('gsPreviewContainer');
+      previewEl.classList.add('gsPreviewContainer', 'blurPreview');
       previewEl.innerHTML = _document.getElementById(
         'previewTemplate'
       ).innerHTML;

--- a/src/js/gsSuspendedTab.js
+++ b/src/js/gsSuspendedTab.js
@@ -213,7 +213,8 @@ var gsSuspendedTab = (function() {
       const previewEl = _document.createElement('div');
       const bodyEl = _document.getElementsByTagName('body')[0];
       previewEl.setAttribute('id', 'gsPreviewContainer');
-      previewEl.classList.add('gsPreviewContainer', 'blurPreview');
+      previewEl.classList.add('gsPreviewContainer');
+      alert(gsStorage.getOption(SCREEN_CAPTURE_BLUR));
       previewEl.innerHTML = _document.getElementById(
         'previewTemplate'
       ).innerHTML;

--- a/src/js/gsTabSuspendManager.js
+++ b/src/js/gsTabSuspendManager.js
@@ -16,6 +16,9 @@ var gsTabSuspendManager = (function() {
       const forceScreenCapture = gsStorage.getOption(
         gsStorage.SCREEN_CAPTURE_FORCE
       );
+      const blurScreenCapture = gsStorage.getOption(
+        gsStorage.SCREEN_CAPTURE_BLUR
+      );
       //TODO: This should probably update when the screencapture mode changes
       const concurrentSuspensions =
         screenCaptureMode === '0' ? 5 : DEFAULT_CONCURRENT_SUSPENSIONS;

--- a/src/js/gsUtils.js
+++ b/src/js/gsUtils.js
@@ -635,9 +635,10 @@ var gsUtils = {
 
           //if theme or screenshot preferences have changed then refresh suspended tabs
           const updateTheme = changedSettingKeys.includes(gsStorage.THEME);
-          const updatePreviewMode = changedSettingKeys.includes(
-            gsStorage.SCREEN_CAPTURE
-          );
+          const updatePreviewMode = changedSettingKeys.some(key => [
+            gsStorage.SCREEN_CAPTURE,
+            gsStorage.SCREEN_CAPTURE_BLUR,
+          ].includes(key));
           if (updateTheme || updatePreviewMode) {
             const suspendedView = tgs.getInternalViewByTabId(tab.id);
             if (suspendedView) {
@@ -657,10 +658,14 @@ var gsUtils = {
                 const previewMode = gsStorage.getOption(
                   gsStorage.SCREEN_CAPTURE
                 );
+                const useBlur = gsStorage.getOption(
+                  gsStorage.SCREEN_CAPTURE_BLUR
+                );
                 gsSuspendedTab.updatePreviewMode(
                   suspendedView,
                   tab,
-                  previewMode
+                  previewMode,
+                  useBlur,
                 ); // async. unhandled promise.
               }
             }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -10,6 +10,7 @@
   var elementPrefMap = {
     preview: gsStorage.SCREEN_CAPTURE,
     forceScreenCapture: gsStorage.SCREEN_CAPTURE_FORCE,
+    blurScreenCapture: gsStorage.SCREEN_CAPTURE_BLUR,
     suspendInPlaceOfDiscard: gsStorage.SUSPEND_IN_PLACE_OF_DISCARD,
     onlineCheck: gsStorage.IGNORE_WHEN_OFFLINE,
     batteryCheck: gsStorage.IGNORE_WHEN_CHARGING,
@@ -103,8 +104,12 @@
     if (visible) {
       document.getElementById('forceScreenCaptureContainer').style.display =
         'block';
+      document.getElementById('blurScreenCaptureContainer').style.display = 
+        'block';
     } else {
       document.getElementById('forceScreenCaptureContainer').style.display =
+        'none';
+      document.getElementById('blurScreenCaptureContainer').style.display =
         'none';
     }
   }

--- a/src/options.html
+++ b/src/options.html
@@ -186,6 +186,10 @@ __MSG_html_options_suspend_force_screen_capture_tooltip_line7__">
 						<i class="tooltipIcon icon icon-help-circled"></i>
 					</span>
 				</div>
+				<div class="formRow" id="blurScreenCaptureContainer">
+					<input type="checkbox" id="blurScreenCapture" class='option' />
+					<label for="blurScreenCapture" class="cbLabel" data-i18n="__MSG_html_options_suspend_blur_screen_capture__&nbsp;&nbsp;"></label>
+				</div>
 			</div>
 			<div class="sub-section">
 


### PR DESCRIPTION
I tried implementing a mode where the preview image is used as a backdrop / watermark:
![image](https://user-images.githubusercontent.com/23227405/107036681-4c808080-67ba-11eb-930f-14af8989d5b9.png)
I wanted to blur the image and fill the entire background. For that I made some changes to the css that should be backwards compatible.

Currently, there are no settings for turning blurring on / off. 