### PR TITLE
Seamless migration

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -75,6 +75,7 @@
     "html_options_suspend_no_forms": { "message": "Never suspend tabs that contain unsaved form inputs" },
     "html_options_suspend_no_audio": { "message": "Never suspend tabs that are playing audio" },
     "html_options_suspend_only_connected": { "message": "Never suspend tabs when offline" },
+    "html_options_suspend_claim_by_default": { "message": "Claim by deafult (seamless migration; tab consider suspended if 'suspended.html' is in url)" },
     "html_options_suspend_only_on_battery": { "message": "Never suspend tabs when connected to power source" },
     "html_options_suspend_no_active_tabs": { "message": "Never suspend active tab in each window" },
     "html_options_suspend_automatically_unsuspend": { "message": "Automatically unsuspend tab when it is viewed" },

--- a/src/js/gsStorage.js
+++ b/src/js/gsStorage.js
@@ -9,6 +9,7 @@ var gsStorage = {
   SUSPEND_TIME: 'gsTimeToSuspend',
   IGNORE_WHEN_OFFLINE: 'onlineCheck',
   IGNORE_WHEN_CHARGING: 'batteryCheck',
+  CLAIM_BY_DEFAULT: 'claimByDefault',
   IGNORE_PINNED: 'gsDontSuspendPinned',
   IGNORE_FORMS: 'gsDontSuspendForms',
   IGNORE_AUDIO: 'gsDontSuspendAudio',
@@ -41,6 +42,7 @@ var gsStorage = {
     defaults[gsStorage.DISCARD_AFTER_SUSPEND] = false;
     defaults[gsStorage.IGNORE_WHEN_OFFLINE] = false;
     defaults[gsStorage.IGNORE_WHEN_CHARGING] = false;
+    defaults[gsStorage.CLAIM_BY_DEFAULT] = false;
     defaults[gsStorage.UNSUSPEND_ON_FOCUS] = false;
     defaults[gsStorage.IGNORE_PINNED] = true;
     defaults[gsStorage.IGNORE_FORMS] = true;

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -14,6 +14,7 @@
     onlineCheck: gsStorage.IGNORE_WHEN_OFFLINE,
     batteryCheck: gsStorage.IGNORE_WHEN_CHARGING,
     unsuspendOnFocus: gsStorage.UNSUSPEND_ON_FOCUS,
+    claimByDefault: gsStorage.CLAIM_BY_DEFAULT,
     discardAfterSuspend: gsStorage.DISCARD_AFTER_SUSPEND,
     dontSuspendPinned: gsStorage.IGNORE_PINNED,
     dontSuspendForms: gsStorage.IGNORE_FORMS,

--- a/src/options.html
+++ b/src/options.html
@@ -100,6 +100,11 @@
 					<label for="batteryCheck" class="cbLabel" data-i18n="__MSG_html_options_suspend_only_on_battery__"></label>
 				</div>
 				<div class="formRow autoSuspendOption">
+					<input type="checkbox" id="claimByDefault" class='option' />
+                    			<label for="claimByDefault" class="cbLabel" data-i18n="__MSG_html_options_suspend_claim_by_default__"></label>
+               			 </div>
+
+				<div class="formRow autoSuspendOption">
 					<label id="whitelistLbl" for="whitelist" data-i18n="__MSG_html_options_whitelist_title__&nbsp;&nbsp;"></label>
 					<span data-i18n-tooltip="__MSG_html_options_whitelist_tooltip_line1__
 &nbsp;&nbsp;&nbsp;&nbsp;https://play.google.com/music/listen


### PR DESCRIPTION
Maybe there is a better way to do this (something like changing initTab function in gsSuspendedTab.js), but it's the most obvious i think.

Tested cases:
It won't breaks if other extension handle your tab now.
It works whether only one new tab will be open in current window or the whole new window will be open.