### PR TITLE
Fix unspoken meaning translation

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -47,6 +47,7 @@
     "html_about_browserstack_prefix": { "message": "Thank you also to" },
     "html_about_browserstack_suffix": { "message": "for providing free chrome testing tools." },
     "html_about_tgs_prefix": { "message": "This extension could never have existed without" },
+    "html_about_tgs_suffix": { "message": "." },
     "html_broken_title": { "message": "is broken" },
     "html_broken_ruh_roh": { "message": "Ruh Roh!" },
     "html_broken_line1": { "message": "failed to start. Perhaps you are using an incompatible version of Chrome?" },

--- a/src/about.html
+++ b/src/about.html
@@ -81,7 +81,8 @@
 				</p>
 				<p>
 					<span data-i18n="__MSG_html_about_tgs_prefix__ "></span>
-					<a href="https://github.com/greatsuspender/thegreatsuspender" target="_blank">The Great Suspender</a>.
+					<a href="https://github.com/greatsuspender/thegreatsuspender" target="_blank">The Great Suspender</a>
+					<span data-i18n="__MSG_html_about_tgs_suffix__ "></span>
 				</p>
 			</div>
 


### PR DESCRIPTION
Fix the unspoken meaning translation of Traditional Chinese by adding "html_about_tgs_suffix" on the "About" page.

By adding  "html_about_tgs_suffix", I will be able to fix the translation from 
「没有这个扩展，就不可能存在 **The Great Suspender**」to「如果沒有 **The Great Suspender**，這個擴充功能就不可能存在。」. The original translation has a different meaning from the original English sentence. Also, I can't translate it properly without adding a new string.