### PR TITLE
Small translation fix (Forgot a space)

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -591,7 +591,7 @@
         "message": "Eine automatische Sicherung deiner Tabs wurde vor der Aktualisierung angelegt."
     },
     "html_updated_info_line2_prefix": {
-        "message": "Sollte etwas während der Aktualisierung schief gehen, öffne die"
+        "message": "Sollte etwas während der Aktualisierung schief gehen, öffne die "
     },
     "html_updated_info_line2_suffix": {
         "message": " Seite."


### PR DESCRIPTION
A little translation mistake I came across when I updated to the new version.

Great work btw!