### PR TITLE
JS validation fix for document.body (non-existent for SVG) before using its scrollTop property

### DIFF
--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -119,7 +119,7 @@
             ? 'tempWhitelist'
             : 'normal',
       scrollPos:
-        document.body.scrollTop || document.documentElement.scrollTop || 0,
+        (document.body || document.documentElement || {}).scrollTop || 0,
     };
   }
 


### PR DESCRIPTION
SVG files opened in a separate tab keeps generating JS errors due to wrong validation.