### PR TITLE
Fix "minutes" translation

### DIFF
--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -222,7 +222,7 @@
         "message": "dakika"
     },
     "html_options_suspend_minutes": {
-        "message": "saniye"
+        "message": "dakika"
     },
     "html_options_suspend_hour": {
         "message": "saat"


### PR DESCRIPTION
"minutes" doesn't mean "saniye" in Turkish. With the existing translation, the timeout options show like this:

<img width="151" alt="CleanShot 2022-08-04 at 12 42 11@2x" src="https://user-images.githubusercontent.com/166637/182816598-4bfe9826-0b05-4118-95dd-f480484bfadd.png">

which is weird. It goes from seconds to minutes, back to seconds, then to hours. At first I thought there is an issue with the options but it turned out it is just a mistake in the translation.