### PR TITLE
Option for automatic light/dark mode from system theme

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -97,6 +97,7 @@
     "html_options_suspend_discard_after_suspend_tooltip_line3a": { "message": "For more information on Chrome discarding refer to:" },
     "html_options_suspend_discard_after_suspend_tooltip_line3b": { "message": "https://developers.google.com/web/updates/2015/09/tab-discarding" },
     "html_options_suspend_theme": { "message": "Theme" },
+    "html_options_suspend_theme_system": { "message": "System" },
     "html_options_suspend_theme_light": { "message": "Light" },
     "html_options_suspend_theme_dark": { "message": "Dark" },
     "html_options_suspend_screen_capturing": { "message": "Screen capturing" },

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -75,11 +75,31 @@ a {
 .menuOption:hover .optionText {
   text-decoration: underline;
 }
+/* color scheme selection */
+:root {
+  color-scheme: light dark;
+}
+:root.light {
+  color-scheme: light;
+}
+:root.dark {
+  color-scheme: dark;
+}
 /* dark theme for night lurkers */
-.dark {
+.dark body {
   background: #353535;
   color: #b8b8b8;
 }
 .dark .group {
   border-color: #555;
 }
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #353535;
+    color: #b8b8b8;
+  }
+  .group {
+    border-color: #555;
+  }
+}
+

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -600,9 +600,20 @@ input[type='checkbox']:checked + label:before {
     animation: spinner .6s linear infinite;
 }
 
-
+/* color scheme selection */
+:root {
+    color-scheme: light dark;
+}
+:root.light {
+    color-scheme: light;
+}
+:root.dark {
+    color-scheme: dark;
+}
 /* dark theme */
-.dark, .dark .option, .dark .historyLink {
+.dark body,
+.dark .option,
+.dark .historyLink {
     background: #353535;
     color: #b8b8b8;
 }
@@ -615,3 +626,19 @@ input[type='checkbox']:checked + label:before {
     background: #3477db;
 }
 
+@media (prefers-color-scheme: dark) {
+    body,
+    .option,
+    .historyLink {
+        background: #353535;
+        color: #b8b8b8;
+    }
+
+    .tooltipIcon {
+        color: white;
+    }
+
+    .btn {
+        background: #3477db;
+    }
+}

--- a/src/css/suspended.css
+++ b/src/css/suspended.css
@@ -8,6 +8,16 @@
    - (_/  \_) - \_)
 
 */
+/* color scheme selection */
+:root {
+  color-scheme: light dark;
+}
+:root.light {
+  color-scheme: light;
+}
+:root.dark {
+  color-scheme: dark;
+}
 html,
 body {
     margin: 0;
@@ -104,6 +114,11 @@ body.suspended-page:not(.img-preview-mode) {
 .dark .faviconWrapLowContrast {
     filter: invert(1) grayscale(1);
 }
+@media (prefers-color-scheme: dark) {
+    .faviconWrapLowContrast {
+        filter: invert(1) grayscale(1);
+    }
+}
 .gsTopBarImg {
     height: 16px;
     width: 16px;
@@ -153,6 +168,15 @@ body.suspended-page:not(.img-preview-mode) {
 }
 .dark .gsPreviewImg:hover {
     opacity: 1;
+}
+@media (prefers-color-scheme: dark) {
+    .gsPreviewImg {
+        filter: brightness(70%);
+        opacity: 0.7;
+    }
+    .gsPreviewImg:hover {
+        opacity: 1;
+    }
 }
 body.img-preview-mode .gsTopBar {
     position: relative;
@@ -233,7 +257,7 @@ body.img-preview-mode .gsTopBar {
 }
 
 /* dark theme for night lurkers */
-.dark,
+.dark body,
 .dark .gsTopBar,
 .dark .suspendedMsg {
     background: #222;
@@ -251,6 +275,28 @@ body.img-preview-mode .gsTopBar {
 .dark #setKeyboardShortcut {
     text-decoration: underline;
     color: #b8b8b8;
+}
+
+@media (prefers-color-scheme: dark) {
+    body,
+    .gsTopBar,
+    .suspendedMsg {
+        background: #222;
+    }
+    .suspendedMsg img {
+        filter: brightness(150%);
+    }
+    .gsTopBar,
+    .gsTopBarTitle,
+    .gsTopBar a,
+    .suspendedMsg,
+    .watermark {
+        color: #b8b8b8;
+    }
+    #setKeyboardShortcut {
+        text-decoration: underline;
+        color: #b8b8b8;
+    }
 }
 
 /* end suspended tab styles */

--- a/src/js/about.js
+++ b/src/js/about.js
@@ -11,7 +11,8 @@
 
   gsUtils.documentReadyAndLocalisedAsPromised(document).then(function() {
     //Set theme
-    document.body.classList.add(gsStorage.getOption(gsStorage.THEME) === 'dark' ? 'dark' : null);
+    let themeOption = gsStorage.getOption(gsStorage.THEME)
+    document.documentElement.classList.add(themeOption === 'light' ? 'light' : themeOption === 'dark' ? 'dark' : null);
 
     var versionEl = document.getElementById('aboutVersion');
     versionEl.innerHTML = 'v' + chrome.runtime.getManifest().version;

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -78,7 +78,8 @@
 
   gsUtils.documentReadyAndLocalisedAsPromised(document).then(async function() {
     //Set theme
-    document.body.classList.add(gsStorage.getOption(gsStorage.THEME) === 'dark' ? 'dark' : null);
+    let themeOption = gsStorage.getOption(gsStorage.THEME)
+    document.documentElement.classList.add(themeOption === 'light' ? 'light' : themeOption === 'dark' ? 'dark' : null);
     await fetchInfo();
     addFlagHtml(
       'toggleDebugInfo',

--- a/src/js/gsSuspendedTab.js
+++ b/src/js/gsSuspendedTab.js
@@ -176,10 +176,15 @@ var gsSuspendedTab = (function() {
   }
 
   function setTheme(_document, theme, isLowContrastFavicon) {
-    if (theme === 'dark') {
-      _document.querySelector('body').classList.add('dark');
+    if (theme === 'light') {
+      _document.querySelector(':root').classList.add('light');
     } else {
-      _document.querySelector('body').classList.remove('dark');
+      _document.querySelector(':root').classList.remove('light');
+    }
+    if (theme === 'dark') {
+      _document.querySelector(':root').classList.add('dark');
+    } else {
+      _document.querySelector(':root').classList.remove('dark');
     }
 
     if (theme === 'dark' && isLowContrastFavicon) {

--- a/src/js/history.js
+++ b/src/js/history.js
@@ -217,7 +217,8 @@
 
   function render() {
     //Set theme
-    document.body.classList.add(gsStorage.getOption(gsStorage.THEME) === 'dark' ? 'dark' : null);
+    let themeOption = gsStorage.getOption(gsStorage.THEME)
+    document.documentElement.classList.add(themeOption === 'light' ? 'light' : themeOption === 'dark' ? 'dark' : null);
 
     let currentDiv = document.getElementById('currentSessions'),
       sessionsDiv = document.getElementById('recoverySessions'),

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -44,7 +44,8 @@
   //populate settings from synced storage
   function initSettings() {
     //Set theme
-    document.body.classList.add(gsStorage.getOption(gsStorage.THEME) === 'dark' ? 'dark' : null);
+    let themeOption = gsStorage.getOption(gsStorage.THEME)
+    document.documentElement.classList.add(themeOption === 'light' ? 'light' : themeOption === 'dark' ? 'dark' : null);
 
     var optionEls = document.getElementsByClassName('option'),
       pref,

--- a/src/js/shortcuts.js
+++ b/src/js/shortcuts.js
@@ -11,7 +11,8 @@
 
   gsUtils.documentReadyAndLocalisedAsPromised(document).then(function() {
     //Set theme
-    document.body.classList.add(gsStorage.getOption(gsStorage.THEME) === 'dark' ? 'dark' : null);
+    let themeOption = gsStorage.getOption(gsStorage.THEME)
+    document.documentElement.classList.add(themeOption === 'light' ? 'light' : themeOption === 'dark' ? 'dark' : null);
 
     var shortcutsEl = document.getElementById('keyboardShortcuts');
     var configureShortcutsEl = document.getElementById('configureShortcuts');

--- a/src/options.html
+++ b/src/options.html
@@ -154,6 +154,7 @@ __MSG_html_options_suspend_discard_after_suspend_tooltip_line3b__'>
         <br />
         <div class='select-wrapper'>
           <select id='theme' class='option'>
+            <option value='system' data-i18n='__MSG_html_options_suspend_theme_system__'></option>
             <option value='light' data-i18n='__MSG_html_options_suspend_theme_light__'></option>
             <option value='dark' data-i18n='__MSG_html_options_suspend_theme_dark__'></option>
           </select>


### PR DESCRIPTION
This adds an option for a "system" theme that will pull the light or dark mode setting from the browser in CSS. Currently this duplicates the dark mode styles, but could be modified in the future to use the [light-dark](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) function and remove style duplication [once browser support is no longer a concern](https://caniuse.com/mdn-css_types_color_light-dark).

The new system theme will be the default for new installs, but existing installs will maintain their current theme setting.