### PR TITLE
Add tabGroups details to session recovery storage

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -57,6 +57,7 @@ import  { tgs }                   from './tgs.js';
     }
 
     // if (gsUtils.debugInfo) {
+    //   chrome.storage.local.remove([gsStorage.LAST_EXTENSION_RECOVERY]);
     //   setTimeout(() => {
     //     // chrome.tabs.create({ url: `${getSuspendURL()}#ttl=Google+1&uri=https://www.google.com` });
     //     // chrome.tabs.create({ url: `${getSuspendURL()}#ttl=Google+2&uri=https://www.google.com` });
@@ -65,6 +66,7 @@ import  { tgs }                   from './tgs.js';
     //     // chrome.tabs.create({ url: `${getSuspendURL()}#ttl=GitHub+2&uri=https://www.github.com` });
     //     // chrome.tabs.create({ url: `${getSuspendURL()}#ttl=GitHub+3&uri=https://www.github.com` });
     //     chrome.tabs.create({ url: chrome.runtime.getURL('debug.html') });
+    //     chrome.tabs.create({ url: chrome.runtime.getURL('options.html') });
     //   }, 200);
     // }
 

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -57,13 +57,13 @@ import  { tgs }                   from './tgs.js';
         )
       );
     }
+    const rows = [];
     const debugInfos = await Promise.all(debugInfoPromises);
     for (const debugInfo of debugInfos) {
-      var html,
-        tableEl = document.getElementById('gsProfilerBody');
-      html = generateTabInfo(debugInfo);
-      tableEl.innerHTML = tableEl.innerHTML + html;
+      rows.push(generateTabInfo(debugInfo));
     }
+    const tableEl = document.getElementById('gsProfilerBody');
+    tableEl.innerHTML = rows.join('\n');
   }
 
   async function addFlagHtml(elementId, getterFn, setterFn) {
@@ -80,6 +80,11 @@ import  { tgs }                   from './tgs.js';
     //Set theme
     document.body.classList.add(await gsStorage.getOption(gsStorage.THEME) === 'dark' ? 'dark' : null);
     await fetchInfo();
+
+    window.onfocus = () => {
+      fetchInfo();
+    };
+
     addFlagHtml(
       'toggleDebugInfo',
       () => gsUtils.isDebugInfo(),
@@ -95,6 +100,7 @@ import  { tgs }                   from './tgs.js';
       async ()        =>    await gsStorage.getOption(gsStorage.DISCARD_IN_PLACE_OF_SUSPEND),
       async (newVal)  => {  await gsStorage.setOptionAndSync(gsStorage.DISCARD_IN_PLACE_OF_SUSPEND, newVal); }
     );
+
     document.getElementById('claimSuspendedTabs').onclick = async function(e) {
       const tabs = await gsChrome.tabsQuery();
       for (const tab of tabs) {

--- a/src/js/gsChrome.js
+++ b/src/js/gsChrome.js
@@ -155,12 +155,23 @@ export const gsChrome = {
   },
   windowsGetAll: function() {
     return new Promise(resolve => {
-      chrome.windows.getAll({ populate: true }, windows => {
+      chrome.windows.getAll({ populate: true }, (windows) => {
         if (chrome.runtime.lastError) {
-          gsUtils.warning('chromeWindows', chrome.runtime.lastError);
+          gsUtils.warning('windowsGetAll', chrome.runtime.lastError);
           windows = [];
         }
         resolve(windows);
+      });
+    });
+  },
+  tabGroupsGetAll: function() {
+    return new Promise(resolve => {
+      chrome.tabGroups.query({}, (groups) => {
+        if (chrome.runtime.lastError) {
+          gsUtils.warning('tabGroupsGetAll', chrome.runtime.lastError);
+          groups = [];
+        }
+        resolve(groups);
       });
     });
   },

--- a/src/js/gsSession.js
+++ b/src/js/gsSession.js
@@ -77,8 +77,10 @@ export const gsSession = (function() {
     return gsSessionId;
   }
 
+  // @BUG: Tab Groups
   async function buildCurrentSession() {
-    const currentWindows = await gsChrome.windowsGetAll();
+    const currentWindows    = await gsChrome.windowsGetAll();
+    const currentTabGroups  = await gsChrome.tabGroupsGetAll();
     const tabsExist = currentWindows.some(
       window => window.tabs && window.tabs.length,
     );
@@ -89,6 +91,7 @@ export const gsSession = (function() {
     return {
       sessionId: await getSessionId(),
       windows: currentWindows,
+      tabGroups: currentTabGroups,
       date: new Date().toISOString(),
     };
   }
@@ -400,6 +403,7 @@ export const gsSession = (function() {
     return true;
   }
 
+  // @BUG: Tab Groups
   async function recoverLostTabs() {
     const lastSession = await gsIndexedDb.fetchLastSession();
     if (!lastSession) {
@@ -673,6 +677,7 @@ export const gsSession = (function() {
     const newTab = await gsChrome.tabsCreate({ windowId: windowId, url: url, index: index, pinned: sessionTab.pinned, active: false });
 
     // Update recovery view (if it exists)
+    gsUtils.log( 'gsUtils', 'createNewTabFromSessionTab', sessionTab );
     gsUtils.log( 'gsUtils', 'createNewTabFromSessionTab', newTab );
     // const contexts = await tgs.getInternalContextsByViewName('recovery');
     // for (const context of contexts) {

--- a/src/js/gsTabCheckManager.js
+++ b/src/js/gsTabCheckManager.js
@@ -217,7 +217,6 @@ export const gsTabCheckManager = (function() {
     }
 
     // Make sure tab is registered as a 'view' of the extension
-    // const suspendedView = tgs.getInternalViewByTabId(tab.id);
     const context = await tgs.getInternalContextByTabId(tab.id);
     if (!context) {
       gsUtils.log( tab.id, QUEUE_ID, 'Could not find an internal view for suspended tab.', tab );

--- a/src/js/gsTabDiscardManager.js
+++ b/src/js/gsTabDiscardManager.js
@@ -100,6 +100,8 @@ export const gsTabDiscardManager = (function() {
     resolve(false);
   }
 
+  // @TODO: This feature apparently causes tabs to suspend before their normal waiting period
+  //        https://github.com/gioxx/MarvellousSuspender/discussions/254#discussioncomment-13668805
   async function handleDiscardedUnsuspendedTab(tab) {
     if (
       await gsUtils.shouldSuspendDiscardedTabs() &&

--- a/src/js/gsTabQueue.js
+++ b/src/js/gsTabQueue.js
@@ -122,15 +122,13 @@ function init(queueId, queueProps) {
 
     function addTabToQueue(tabDetails) {
       const tab = tabDetails.tab;
-      gsUtils.log(tab.id, _queueId, 'addTabToQueue queue', _queuedTabIds.length, tab.url);
       _tabDetailsByTabId[tab.id] = tabDetails;
       _queuedTabIds.push(tab.id);
-      gsUtils.log(tab.id, _queueId, 'addTabToQueue queue', _queuedTabIds.length, tab.url);
+      gsUtils.log(tab.id, _queueId, 'addTabToQueue queue', _queuedTabIds.length);
     }
 
     function removeTabFromQueue(tabDetails) {
       const tab = tabDetails.tab;
-      gsUtils.log(tab.id, _queueId, 'removeTabFromQueue queue', _queuedTabIds.length, tab.url);
       delete _tabDetailsByTabId[tab.id];
       for (const [i, tabId] of _queuedTabIds.entries()) {
         if (tabId === tab.id) {
@@ -138,7 +136,7 @@ function init(queueId, queueProps) {
           break;
         }
       }
-      gsUtils.log(tab.id, _queueId, 'removeTabFromQueue queue', _queuedTabIds.length, tab.url);
+      gsUtils.log(tab.id, _queueId, 'removeTabFromQueue queue', _queuedTabIds.length);
     }
 
     // eslint-disable-next-line no-unused-vars

--- a/src/js/gsUtils.js
+++ b/src/js/gsUtils.js
@@ -10,25 +10,25 @@ import  { tgs }                   from './tgs.js';
 'use strict';
 
 export const gsUtils = {
-  STATUS_NORMAL: 'normal',
-  STATUS_LOADING: 'loading',
-  STATUS_SPECIAL: 'special',
-  STATUS_BLOCKED_FILE: 'blockedFile',
-  STATUS_SUSPENDED: 'suspended',
-  STATUS_DISCARDED: 'discarded',
-  STATUS_NEVER: 'never',
-  STATUS_FORMINPUT: 'formInput',
-  STATUS_AUDIBLE: 'audible',
-  STATUS_ACTIVE: 'active',
-  STATUS_TEMPWHITELIST: 'tempWhitelist',
-  STATUS_PINNED: 'pinned',
-  STATUS_WHITELISTED: 'whitelisted',
-  STATUS_CHARGING: 'charging',
-  STATUS_NOCONNECTIVITY: 'noConnectivity',
-  STATUS_UNKNOWN: 'unknown',
+  STATUS_NORMAL         : 'normal',
+  STATUS_LOADING        : 'loading',
+  STATUS_SPECIAL        : 'special',
+  STATUS_BLOCKED_FILE   : 'blockedFile',
+  STATUS_SUSPENDED      : 'suspended',
+  STATUS_DISCARDED      : 'discarded',
+  STATUS_NEVER          : 'never',
+  STATUS_FORMINPUT      : 'formInput',
+  STATUS_AUDIBLE        : 'audible',
+  STATUS_ACTIVE         : 'active',
+  STATUS_TEMPWHITELIST  : 'tempWhitelist',
+  STATUS_PINNED         : 'pinned',
+  STATUS_WHITELISTED    : 'whitelisted',
+  STATUS_CHARGING       : 'charging',
+  STATUS_NOCONNECTIVITY : 'noConnectivity',
+  STATUS_UNKNOWN        : 'unknown',
 
-  debugInfo: true,
-  debugError: true,
+  debugInfo: false,
+  debugError: false,
 
   contains: function(array, value) {
     for (var i = 0; i < array.length; i++) {
@@ -608,7 +608,6 @@ export const gsUtils = {
             gsStorage.SCREEN_CAPTURE,
           );
           if (updateTheme || updatePreviewMode) {
-            // const suspendedView = tgs.getInternalViewByTabId(tab.id);
             const context = await tgs.getInternalContextByTabId(tab.id);
             if (context) {
               if (updateTheme) {
@@ -675,9 +674,7 @@ export const gsUtils = {
         });
 
         //if SuspendInPlaceOfDiscard has changed then updated discarded tabs
-        const updateSuspendInPlaceOfDiscard = changedSettingKeys.includes(
-          gsStorage.SUSPEND_IN_PLACE_OF_DISCARD,
-        );
+        const updateSuspendInPlaceOfDiscard = changedSettingKeys.includes( gsStorage.SUSPEND_IN_PLACE_OF_DISCARD );
         if (updateSuspendInPlaceOfDiscard && gsUtils.isDiscardedTab(tab)) {
           gsTabDiscardManager.handleDiscardedUnsuspendedTab(tab); //async. unhandled promise.
           //note: this may cause the tab to suspend

--- a/src/js/tgs.js
+++ b/src/js/tgs.js
@@ -532,7 +532,7 @@ export const tgs = (function() {
     ) {
       return;
     }
-    gsUtils.log( tab.id, 'unsuspended tab state changed. changeInfo: ', changeInfo );
+    gsUtils.log( tab.id, 'unsuspended tab state changed, changeInfo', changeInfo );
 
     // Ensure we clear the STATE_UNLOADED_URL flag during load in case the
     // tab is suspended again before loading can finish (in which case on
@@ -554,7 +554,7 @@ export const tgs = (function() {
         //TODO: Report chrome bug
         return;
       }
-      gsUtils.log( tab.id, 'Unsuspended tab has been discarded. Url: ' + tab.url );
+      gsUtils.log( tab.id, 'Unsuspended tab has been discarded, Url', tab.url );
       gsTabDiscardManager.handleDiscardedUnsuspendedTab(tab); //async. unhandled promise.
 
       // When a tab is discarded the tab id changes. We need up-to-date UNSUSPENDED
@@ -614,7 +614,7 @@ export const tgs = (function() {
           if (!contentScriptStatus) {
             contentScriptStatus = await gsTabCheckManager.queueTabCheckAsPromise( tab, {}, 0 );
           }
-          gsUtils.log( tab.id, 'Content script status: ' + contentScriptStatus );
+          gsUtils.log( tab.id, 'Content script status', contentScriptStatus );
         }
         initialiseTabContentScript(tab, tempWhitelistOnReload, scrollPos)
           .catch(error => {
@@ -738,7 +738,7 @@ export const tgs = (function() {
   }
 
   async function removeTabIdReferences(tabId) {
-    gsUtils.log(tabId, 'removing tabId references to ' + tabId);
+    gsUtils.log(tabId, 'removing tabId references to', tabId);
 
     const focusedTabByWindow = await getCurrentFocusedTabIdByWindowId();
     for (const windowId of Object.keys(focusedTabByWindow)) {
@@ -843,14 +843,14 @@ export const tgs = (function() {
       if (!contentScriptStatus) {
         contentScriptStatus = await gsTabCheckManager.queueTabCheckAsPromise( focusedTab, {}, 0 );
       }
-      gsUtils.log( focusedTab.id, 'tgs', 'getContentScriptStatus' + contentScriptStatus );
+      gsUtils.log( focusedTab.id, 'tgs', 'getContentScriptStatus', contentScriptStatus );
     }
 
     //update icon
     const status = await new Promise(resolve => {
       calculateTabStatus(focusedTab, contentScriptStatus, resolve);
     });
-    gsUtils.log(focusedTab.id, 'tgs', 'calculateTabStatus' + status);
+    // gsUtils.log(focusedTab.id, 'tgs', 'calculateTabStatus', status);
 
     //if this tab still has focus then update icon
     if ((await getCurrentFocusedTabIdByWindowId())[windowId] === focusedTab.id) {
@@ -1197,11 +1197,11 @@ export const tgs = (function() {
 
   //change the icon to either active or inactive
   function setIconStatus(status, tabId) {
-    // gsUtils.log(tabId, 'Setting icon status: ', status);
+    // gsUtils.log(tabId, 'Setting icon status', status);
     var path = ![gsUtils.STATUS_NORMAL, gsUtils.STATUS_ACTIVE].includes(status)
       ? ICON_SUSPENSION_PAUSED
       : ICON_SUSPENSION_ACTIVE;
-    // gsUtils.log(tabId, 'Setting icon status: ', path);
+    // gsUtils.log(tabId, 'Setting icon status', path);
     chrome.action.setIcon({ path, tabId }, () => {
       if (chrome.runtime.lastError) {
         gsUtils.warning(tabId, chrome.runtime.lastError);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,8 @@
     "history",
     "scripting",
     "storage",
-    "tabs"
+    "tabs",
+    "tabGroups"
   ],
   "host_permissions": [
     "https://*/*",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,19 +4,20 @@
   "version": "8.0.0.0",
   "default_locale": "en",
   "permissions": [
-    "alarms",
+    "tabs",
+    "storage",
+    "history",
+    "unlimitedStorage",
     "contextMenus",
     "cookies",
+    "alarms",
     "favicon",
-    "history",
     "scripting",
-    "storage",
-    "tabs",
     "tabGroups"
   ],
   "host_permissions": [
-    "https://*/*",
-    "http://*/*"
+    "http://*/*",
+    "https://*/*"
   ],
   "background": {
     "service_worker": "js/background.js",


### PR DESCRIPTION
This PR will give us the ability to recover tab groups during extension upgrades.

NOTE:  There's no way for us to preserve tab groups in the next update, because the data isn't stored anywhere.  But going forward we'll be able to rebuild tab groups along with tab recovery during upgrades.
