### PR TITLE
Go to "Sessions Management" faster 😄

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -26,7 +26,7 @@
     "js_context_force_suspend_all_tabs": { "message": "Force suspend all tabs in all windows" },
     "js_context_unsuspend_all_tabs": { "message": "Unsuspend all tabs in all windows" },
     "html_about_title": { "message": "About" },
-	"html_about_fork_beginning": { "message": "Based on the original" },
+	  "html_about_fork_beginning": { "message": "Based on the original" },
     "html_about_fork_mid": { "message": "available on GitHub, without ADS tracking" },
     "html_about_fork_end": { "message": ", more information available on" },
     "html_about_github_title": { "message": "GitHub" },

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -392,7 +392,7 @@ a.historyLink:hover {
     margin-left: 28px;
 }
 
-/* conatiner for a group of sessions */
+/* container for a group of sessions */
 .sessionsContainer {
     margin-bottom: 50px;
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -180,6 +180,10 @@ import  { tgs }                   from './tgs.js';
         tgs.whitelistHighlightedTab(true);
         break;
       }
+      case 'sessionManagerLink': {
+        chrome.tabs.create({ url: chrome.runtime.getURL('history.html') });
+        break;
+      }
       case 'settingsLink' : {
         chrome.tabs.create({ url: chrome.runtime.getURL('options.html') });
         break;
@@ -292,6 +296,9 @@ import  { tgs }                   from './tgs.js';
       case 'unsuspend_all_tabs':
         tgs.unsuspendAllTabsInAllWindows();
         break;
+      case 'open_session_history':
+        chrome.tabs.create({ url: chrome.runtime.getURL('history.html') });
+        break;
       default:
         break;
     }
@@ -329,6 +336,9 @@ import  { tgs }                   from './tgs.js';
         break;
       case '6-unsuspend-all-windows':
         tgs.unsuspendAllTabsInAllWindows();
+        break;
+      case '7-open_session_history':
+        chrome.tabs.create({ url: chrome.runtime.getURL('history.html') });
         break;
     }
   }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -272,6 +272,7 @@ import  { tgs }                   from './tgs.js';
     addClickListener('unsuspendSelected');
     addClickListener('whitelistDomain');
     addClickListener('whitelistPage');
+    addClickListener('sessionManagerLink');
     addClickListener('settingsLink');
   }
 

--- a/src/js/shortcuts.js
+++ b/src/js/shortcuts.js
@@ -18,6 +18,7 @@ import  { gsUtils }               from './gsUtils.js';
       '2-toggle-temp-whitelist-tab',
       '2b-unsuspend-selected-tabs',
       '4-unsuspend-active-window',
+      '6-unsuspend-all-windows'
     ];
 
     //populate keyboard shortcuts

--- a/src/js/tgs.js
+++ b/src/js/tgs.js
@@ -44,7 +44,7 @@ export const tgs = (function() {
 
   async function getInternalContextsByViewName(viewName, callback) {
     const contexts = await chrome.runtime.getContexts({});
-    return contexts.filter((o) => o.documentUrl.includes(viewName));
+    return contexts.filter((context) => context.documentUrl?.includes(viewName));
   }
 
 

--- a/src/js/tgs.js
+++ b/src/js/tgs.js
@@ -1322,6 +1322,17 @@ export const tgs = (function() {
         contexts: allContexts,
         // onclick: () => unsuspendAllTabsInAllWindows(),
       });
+
+      chrome.contextMenus.create({
+        id: 'separator4',
+        type: 'separator',
+        contexts: allContexts,
+      });
+      chrome.contextMenus.create({
+        id: 'open_session_history',
+        title: chrome.i18n.getMessage('html_recovery_go_to_session_manager'),
+        contexts: allContexts,
+      });
     }
   }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -85,6 +85,9 @@
     },
     "6-unsuspend-all-windows": {
       "description": "__MSG_ext_cmd_unsuspend_all_windows_description__"
+    },
+    "7-open_session_history": {
+      "description": "__MSG_html_recovery_go_to_session_manager__"
     }
   }
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -46,6 +46,9 @@
 		</div>
 
 		<div class="group">
+			<div class="menuOption" id="sessionManagerLink">
+				<span class="optionText" data-i18n="__MSG_html_sidebar_session_management__"></span>
+			</div>
 			<div class="menuOption" id="settingsLink">
 				<span class="optionText" data-i18n="__MSG_html_popup_settings__"></span>
 			</div>


### PR DESCRIPTION
This update provides a direct link to the Session Management page within the extension's main menu (in the toolbar), within the context menu (right-click), and within the available Shortcuts.
Fix for #116 #224