### PR TITLE
Fix #277, TypeError undefined

### DIFF
--- a/src/js/tgs.js
+++ b/src/js/tgs.js
@@ -44,7 +44,7 @@ export const tgs = (function() {
 
   async function getInternalContextsByViewName(viewName, callback) {
     const contexts = await chrome.runtime.getContexts({});
-    return contexts.filter((o) => o.documentUrl.includes(viewName));
+    return contexts.filter((context) => context.documentUrl?.includes(viewName));
   }
 
 


### PR DESCRIPTION
Didn't realize the context list from Chrome included one for the background service worker, which apparently doesn't have a documentUrl. We can safely skip any context without a documentUrl

It's safe to delete this branch after merge.

Closes #277 
