### PR TITLE
Fix: Add defensive null checks for queue variables (Issue #299)

### DIFF
--- a/src/js/gsTabCheckManager.js
+++ b/src/js/gsTabCheckManager.js
@@ -107,6 +107,10 @@ export const gsTabCheckManager = (function() {
   }
 
   function updateQueueProps(jobTimeout, processingDelay, concurrentExecutors) {
+    if (!_tabCheckQueue) {
+      gsUtils.log(QUEUE_ID, 'Tab check queue not initialized yet.');
+      return;
+    }
     gsUtils.log( QUEUE_ID, `Setting _tabCheckQueue props. jobTimeout: ${jobTimeout}. processingDelay: ${processingDelay}. concurrentExecutors: ${concurrentExecutors}` );
     _tabCheckQueue.setQueueProperties({ jobTimeout, processingDelay, concurrentExecutors, });
   }
@@ -118,12 +122,19 @@ export const gsTabCheckManager = (function() {
   }
 
   function queueTabCheckAsPromise(tab, executionProps, processingDelay) {
+    if (!_tabCheckQueue) {
+      gsUtils.log(tab.id, QUEUE_ID, 'Tab check queue not initialized yet. Ignoring queue request.');
+      return Promise.resolve(gsUtils.STATUS_UNKNOWN);
+    }
     gsUtils.log(tab.id, QUEUE_ID, `Queueing tab for responsiveness check.`);
     executionProps = executionProps || {};
     return _tabCheckQueue.queueTabAsPromise( tab, executionProps, processingDelay );
   }
 
   function unqueueTabCheck(tab) {
+    if (!_tabCheckQueue) {
+      return;
+    }
     const removed = _tabCheckQueue.unqueueTab(tab);
     if (removed) {
       gsUtils.log(tab.id, QUEUE_ID, 'Removed tab from check queue.');
@@ -131,6 +142,9 @@ export const gsTabCheckManager = (function() {
   }
 
   function getQueuedTabCheckDetails(tab) {
+    if (!_tabCheckQueue) {
+      return null;
+    }
     return _tabCheckQueue.getQueuedTabDetails(tab);
   }
 
@@ -259,7 +273,7 @@ export const gsTabCheckManager = (function() {
 
     let reinitialised = false;
     if (!tabChecksOk) {
-      const tabQueueDetails = _tabCheckQueue.getQueuedTabDetails(tab);
+      const tabQueueDetails = getQueuedTabCheckDetails(tab);
       if (!tabQueueDetails) {
         resolve(gsUtils.STATUS_UNKNOWN);
         return;
@@ -373,7 +387,7 @@ export const gsTabCheckManager = (function() {
       return;
     }
 
-    const queuedTabDetails = _tabCheckQueue.getQueuedTabDetails(tab);
+    const queuedTabDetails = getQueuedTabCheckDetails(tab);
     if (!queuedTabDetails) {
       gsUtils.log(tab.id, QUEUE_ID, 'Tab missing from suspensionQueue?');
       resolve(gsUtils.STATUS_UNKNOWN);

--- a/src/js/gsTabDiscardManager.js
+++ b/src/js/gsTabDiscardManager.js
@@ -38,12 +38,19 @@ export const gsTabDiscardManager = (function() {
   }
 
   function queueTabForDiscardAsPromise(tab, executionProps, processingDelay) {
+    if (!_discardQueue) {
+      gsUtils.log(tab.id, QUEUE_ID, 'Discard queue not initialized yet. Ignoring queue request.');
+      return Promise.resolve(false);
+    }
     gsUtils.log(tab.id, QUEUE_ID, `Queueing tab for discarding.`);
     executionProps = executionProps || {};
     return _discardQueue.queueTabAsPromise( tab, executionProps, processingDelay );
   }
 
   function unqueueTabForDiscard(tab) {
+    if (!_discardQueue) {
+      return;
+    }
     const removed = _discardQueue.unqueueTab(tab);
     if (removed) {
       gsUtils.log(tab.id, QUEUE_ID, 'Removed tab from discard queue');

--- a/src/js/gsTabSuspendManager.js
+++ b/src/js/gsTabSuspendManager.js
@@ -47,6 +47,11 @@ export const gsTabSuspendManager = (function() {
   async function queueTabForSuspensionAsPromise(tab, forceLevel) {
     if (typeof tab === 'undefined') return Promise.resolve();
 
+    if (!_suspensionQueue) {
+      gsUtils.log(tab.id, QUEUE_ID, 'Suspension queue not initialized yet. Ignoring queue request.');
+      return Promise.resolve();
+    }
+
     if (!await checkTabEligibilityForSuspension(tab, forceLevel)) {
       gsUtils.log(tab.id, QUEUE_ID, 'Tab not eligible for suspension.');
       return Promise.resolve();
@@ -57,6 +62,10 @@ export const gsTabSuspendManager = (function() {
   }
 
   function unqueueTabForSuspension(tab) {
+    if (!_suspensionQueue) {
+      gsUtils.log(tab.id, QUEUE_ID, 'Suspension queue not initialized yet. Ignoring unqueue request.');
+      return;
+    }
     const removed = _suspensionQueue.unqueueTab(tab);
     if (removed) {
       gsUtils.log(tab.id, QUEUE_ID, 'Removed tab from suspension queue.');
@@ -201,10 +210,19 @@ export const gsTabSuspendManager = (function() {
   }
 
   function getQueuedTabDetails(tab) {
+    if (!_suspensionQueue) {
+      gsUtils.log(tab.id, QUEUE_ID, 'Suspension queue not initialized yet.');
+      return null;
+    }
     return _suspensionQueue.getQueuedTabDetails(tab);
   }
 
   async function handleSuspensionException( tab, executionProps, exceptionType, resolve, reject, requeue ) {
+    if (!_suspensionQueue) {
+      gsUtils.log(tab.id, QUEUE_ID, 'Suspension queue not initialized. Resolving exception as failure.');
+      resolve(false);
+      return;
+    }
     if (exceptionType === _suspensionQueue.EXCEPTION_TIMEOUT) {
       gsUtils.log( tab.id, QUEUE_ID, `Tab took more than ${ _suspensionQueue.getQueueProperties().jobTimeout }ms to suspend. Will force suspension.` );
       const success = await executeTabSuspension( tab, executionProps.suspendedUrl, );


### PR DESCRIPTION
## Summary

Adds defensive null checks to prevent TypeErrors when Chrome's service worker lifecycle unloads and restarts the extension during idle periods.

## Problem

When the service worker is unloaded by Chrome (Memory Saver, idle timeout, etc.), the queue variables (`_suspensionQueue`, `_tabCheckQueue`, `_discardQueue`) become undefined. If any queue method is called before `initAsPromised()` completes on restart, a TypeError occurs:

```
TypeError: Cannot read properties of undefined (reading 'unqueueTab')
    at unqueueTabForSuspension (gsTabSuspendManager.js:60)
```

## Solution

Added null checks at the entry point of all public functions that access the queue variables. Functions now gracefully return early (with appropriate logging) if the queue hasn't been initialized yet.

## Files Changed

- `src/js/gsTabSuspendManager.js` - 4 functions protected
- `src/js/gsTabCheckManager.js` - 4 functions protected  
- `src/js/gsTabDiscardManager.js` - 2 functions protected

## Testing

- [ ] Tested with Chrome's Memory Saver enabled
- [ ] Verified no TypeErrors after idle periods
- [ ] Extension recovers gracefully when service worker restarts

> **Note:** Currently testing this fix - will update with results. Opening PR now to track the fix and get feedback on the approach.

Fixes #299