### PR TITLE
Fix: Data URI tabs crash session manager (Issue #336)

### DIFF
--- a/src/js/gsFavicon.js
+++ b/src/js/gsFavicon.js
@@ -158,9 +158,18 @@ export const gsFavicon = (() => {
     // }
 
     // Else try one more time with the root hostname -- this is needed for YouTube, for example
-    const fullUrl = new URL(url).toString();
+    // Skip data URIs and other non-standard URLs that don't have a host
+    if (url && url.startsWith('data:')) {
+      return null;
+    }
+    let fullUrl;
+    try {
+      fullUrl = new URL(url).toString();
+    } catch (e) {
+      return null;
+    }
     const hostUrl = gsUtils.getRootUrlNew(fullUrl);
-    if (!fRecursion && fullUrl != hostUrl) {
+    if (!fRecursion && hostUrl && fullUrl != hostUrl) {
       gsUtils.log('gsFavicon', 'Trying root hostname', fullUrl, hostUrl);
       faviconMeta = await getFaviconMetaForUrl(hostUrl, tabFavIconUrl, true);
       if (faviconMeta) {

--- a/src/js/gsUtils.js
+++ b/src/js/gsUtils.js
@@ -448,8 +448,17 @@ export const gsUtils = {
 
   // @TODO: Make some unit tests to verify getRootUrl vs getRootUrlNew
   getRootUrlNew: function(url) {
-    const fullURL = new URL(url);
-    return new URL(`//${fullURL.host}`, fullURL).toString();
+    // Data URIs don't have a host, so return null
+    if (url && url.startsWith('data:')) {
+      return null;
+    }
+    try {
+      const fullURL = new URL(url);
+      return new URL(`//${fullURL.host}`, fullURL).toString();
+    } catch (e) {
+      // Invalid URL (malformed or unsupported scheme)
+      return null;
+    }
   },
 
   getRootUrl: function(url, includePath, includeScheme) {


### PR DESCRIPTION
## Summary

Fixes crash when session manager encounters data URI tabs (e.g., `data:image/svg+xml;base64,...`).

## Problem

Data URIs don't have a host component, so `new URL(dataUri)` throws:
```
TypeError: Failed to construct 'URL': Invalid URL
    at getRootUrlNew (gsUtils.js:452)
```

This cascades through favicon retrieval and crashes the session manager when listing tabs.

## Solution

Added defensive checks in two places:

**gsUtils.js - `getRootUrlNew()`:**
- Early return `null` for `data:` URLs
- Try-catch wrapper for other malformed URLs

**gsFavicon.js - `getFaviconMetaForUrl()`:**
- Early return `null` for `data:` URLs  
- Try-catch around `new URL()` construction
- Added null check for `hostUrl` before comparison

## Testing

- [ ] Open a data URI tab (e.g., drag an image into browser)
- [ ] Open session manager
- [ ] Verify no crash when unfolding current session

Fixes #336