### PR TITLE
Fix for Edge's version of the tab group bug

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -369,11 +369,14 @@ import  { tgs }                   from './tgs.js';
       await tgs.handleTabFocusChanged(activeInfo.tabId, activeInfo.windowId); // async. unhandled promise
     });
     chrome.tabs.onReplaced.addListener(async (addedTabId, removedTabId) => {
-      gsUtils.log(removedTabId, 'tab onReplaced', addedTabId, removedTabId);
+      gsUtils.highlight(removedTabId, 'tab onReplaced', addedTabId, removedTabId);
       // await tgs.updateTabIdReferences(addedTabId, removedTabId);
       tgs.queueSessionTimer();
       await tgs.removeTabIdReferences(removedTabId);
+
+      // This event is rather unique to the Chrome Tab Group Bug, so queue up everything
       gsSession.pushReplacedTab(addedTabId);
+
     });
     chrome.tabs.onCreated.addListener(async (tab) => {
       gsUtils.log(tab.id, 'tab onCreated', tab.url);
@@ -413,7 +416,14 @@ import  { tgs }                   from './tgs.js';
     };
 
     chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+      gsUtils.highlight(tabId, 'tab onUpdated', changeInfo, tab.url);
       if (!changeInfo) return;
+
+      // Edge's version of the Tab Group Bug bug is more complicated.
+      // Here, we need to save the suspended URL and the tabId for grouped tabs
+      if (changeInfo.title == 'New Tab' && tab.groupId && gsUtils.isSuspendedTab(tab)) {
+        gsSession.pushReplacedTab(tabId, tab.url);
+      }
 
       if (await gsStorage.getOption(gsStorage.CLAIM_BY_DEFAULT) && changeInfo.status === 'complete') {
         await claimTab(tabId);

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -421,7 +421,10 @@ import  { tgs }                   from './tgs.js';
 
       // Edge's version of the Tab Group Bug bug is more complicated.
       // Here, we need to save the suspended URL and the tabId for grouped tabs
-      if (changeInfo.title == 'New Tab' && tab.groupId && gsUtils.isSuspendedTab(tab)) {
+      // Originally we limit tab replacement to only suspended tabs, but Edge is braking some live tabs too
+      // if (changeInfo.title == 'New Tab' && tab.groupId && gsUtils.isSuspendedTab(tab)) {
+      if (changeInfo.title?.toLowerCase() == 'new tab' && tab.groupId) {
+        // Attempt to queue up any tab moving to "new tab" -- pushReplacedTab will stop queueing after initialization ends
         gsSession.pushReplacedTab(tabId, tab.url);
       }
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -369,7 +369,7 @@ import  { tgs }                   from './tgs.js';
       await tgs.handleTabFocusChanged(activeInfo.tabId, activeInfo.windowId); // async. unhandled promise
     });
     chrome.tabs.onReplaced.addListener(async (addedTabId, removedTabId) => {
-      gsUtils.highlight(removedTabId, 'tab onReplaced', addedTabId, removedTabId);
+      gsUtils.log(removedTabId, 'tab onReplaced', addedTabId, removedTabId);
       // await tgs.updateTabIdReferences(addedTabId, removedTabId);
       tgs.queueSessionTimer();
       await tgs.removeTabIdReferences(removedTabId);
@@ -416,7 +416,7 @@ import  { tgs }                   from './tgs.js';
     };
 
     chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-      gsUtils.highlight(tabId, 'tab onUpdated', changeInfo, tab.url);
+      gsUtils.log(tabId, 'tab onUpdated', changeInfo, tab.url);
       if (!changeInfo) return;
 
       // Edge's version of the Tab Group Bug bug is more complicated.

--- a/src/js/gsSession.js
+++ b/src/js/gsSession.js
@@ -176,6 +176,7 @@ export const gsSession = (function() {
 
   /** @type { { tabId: number, url ?:string }[] } */
   const replacedTabs  = [];
+  let   allowReplace  = true;
 
   /**
    * @param { number } tabId
@@ -184,8 +185,9 @@ export const gsSession = (function() {
   function pushReplacedTab(tabId, url) {
     // We need to handle the replaced tabs sequentially to ensure proper placement.
     // So, add them to a queue during startup and process them only once below.
-    // @TODO: Stop pushing to the queue after initialization, to reduce memory build-up
-    replacedTabs.push({tabId, url});
+    if (allowReplace) {
+      replacedTabs.push({tabId, url});
+    }
   }
 
   async function handleReplacedTabs() {
@@ -204,11 +206,13 @@ export const gsSession = (function() {
     // Further, since the queued tabId does not have the correct URL, we're sending it into the queue to override the new-tab URL
 
     gsUtils.setTimeout(2000).then(async () => {
+      allowReplace        = false;
       for (const replaceInfo of replacedTabs) {
         const addedTab    = await gsChrome.tabsGet(replaceInfo.tabId);
         const replaceUrl  = replaceInfo.url ?? addedTab?.url;
-        // gsUtils.log(tabId, 'gsSession', 'handleReplacedTabs', addedTab);
-        if (replaceUrl && addedTab?.groupId && gsUtils.isSuspendedUrl(replaceUrl)) {
+        // gsUtils.highlight(replaceInfo.tabId, 'gsSession', 'handleReplacedTabs', addedTab);
+        // if (addedTab?.groupId && replaceUrl && gsUtils.isSuspendedUrl(replaceUrl)) {
+        if (addedTab?.groupId && replaceUrl) {
           const { windowId, index, pinned, active, groupId }  = addedTab;
           const newTab    = await gsChrome.tabsCreate({ windowId, index, pinned, active, url: replaceUrl });
           if (newTab?.id) {

--- a/src/js/gsSession.js
+++ b/src/js/gsSession.js
@@ -174,38 +174,46 @@ export const gsSession = (function() {
   }
 
 
-  /** @type { number[] } */
-  const replacedTabs            = [];
+  /** @type { { tabId: number, url ?:string }[] } */
+  const replacedTabs  = [];
 
   /**
    * @param { number } tabId
+   * @param { string } [url]
    */
-  function pushReplacedTab(tabId) {
+  function pushReplacedTab(tabId, url) {
     // We need to handle the replaced tabs sequentially to ensure proper placement.
     // So, add them to a queue during startup and process them only once below.
-    replacedTabs.push(tabId);
+    // @TODO: Stop pushing to the queue after initialization, to reduce memory build-up
+    replacedTabs.push({tabId, url});
   }
 
   async function handleReplacedTabs() {
     gsUtils.log('gsSession', 'handleReplacedTabs', replacedTabs.length);
     // Work-around for Chrome tab groups bug https://crbug.com/522338670
     // https://github.com/gioxx/MarvellousSuspender/issues/369
+    // https://github.com/gioxx/MarvellousSuspender/issues/374
+    // Chrome:
     // Suspended tabs should never be Replaced in practice
     // The current bug is explicitly Replacing non "web" tabs ( and discarding them )
     // Weirdly / luckily the defunct tab maintains the original URL while also being a "new tab"
     // So, if a Replaced tab is also a Suspended tab, we're going to swap it out for a fresh tab
+    // Edge:
+    // Edge's version of this bug is more complex.  We have to tap into the main tab onUpdated event, which triggers all the time
+    // We only queue up tabs that are suspended, are in a tab group, and are transitions to "new tab"
+    // Further, since the queued tabId does not have the correct URL, we're sending it into the queue to override the new-tab URL
 
     gsUtils.setTimeout(2000).then(async () => {
-      for (const tabId of replacedTabs) {
-        const addedTab    = await gsChrome.tabsGet(tabId);
+      for (const replaceInfo of replacedTabs) {
+        const addedTab    = await gsChrome.tabsGet(replaceInfo.tabId);
+        const replaceUrl  = replaceInfo.url ?? addedTab?.url;
         // gsUtils.log(tabId, 'gsSession', 'handleReplacedTabs', addedTab);
-        if (addedTab?.url && addedTab.groupId && gsUtils.isSuspendedTab(addedTab)) {
-          gsTabCheckManager.queueTabCheck(addedTab, { replaceTab: true }, 3000);
-          const { windowId, url, index, pinned, active, groupId }  = addedTab;
-          const newTab    = await gsChrome.tabsCreate({ windowId, url, index, pinned, active });
+        if (replaceUrl && addedTab?.groupId && gsUtils.isSuspendedUrl(replaceUrl)) {
+          const { windowId, index, pinned, active, groupId }  = addedTab;
+          const newTab    = await gsChrome.tabsCreate({ windowId, index, pinned, active, url: replaceUrl });
           if (newTab?.id) {
             await gsChrome.tabsGroup(newTab.id, windowId, groupId);
-            await gsChrome.tabsRemove(tabId);
+            await gsChrome.tabsRemove(replaceInfo.tabId);
           }
         }
       }

--- a/src/js/gsSession.js
+++ b/src/js/gsSession.js
@@ -192,7 +192,7 @@ export const gsSession = (function() {
 
   async function handleReplacedTabs() {
     gsUtils.log('gsSession', 'handleReplacedTabs', replacedTabs.length);
-    // Work-around for Chrome tab groups bug https://crbug.com/522338670
+    // Work-around for Chrome and Edge tab groups bug https://crbug.com/522338670
     // https://github.com/gioxx/MarvellousSuspender/issues/369
     // https://github.com/gioxx/MarvellousSuspender/issues/374
     // Chrome:

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_ext_extension_name__",
   "description": "__MSG_ext_extension_description__",
-  "version": "8.1.4",
+  "version": "8.1.5",
   "default_locale": "en",
   "permissions": [
     "tabs",


### PR DESCRIPTION
This prototype fix appears to do the trick, but needs some more testing.
Thanks to everyone helping with #374

This PR  is not ready to release just yet
- [x] Testing
- [x] Repair tabs previously recovered by using the Back button
- [x] Update manifest version

This PR should be ready to merge and release.
I'm going hold off on doing it myself, so @gioxx and/or others can perhaps run a few tests before we push out the new version.