### PR TITLE
Merge branch Maint/816

### DIFF
--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -1,5 +1,6 @@
 import  { gsChrome }              from './gsChrome.js';
 import  { gsFavicon }             from './gsFavicon.js';
+import  { gsMessages }            from './gsMessages.js';
 import  { gsStorage }             from './gsStorage.js';
 import  { gsUtils }               from './gsUtils.js';
 import  { tgs }                   from './tgs.js';
@@ -12,6 +13,20 @@ import  { tgs }                   from './tgs.js';
   // 2026-04: Brave colors appear to match chrome nicely
   // 2026-04: Vivaldi and Opera are doing weird things with Tab Groups.  Ignoring their special colors for now.
 
+  /**
+   * @param {{
+   *    timerUp   ? : string
+   *    windowId  ? : string
+   *    tabId     ? : string
+   *    tab       ? : chrome.tabs.Tab
+   *    status    ? : string
+   *    group     ? : {
+   *      title   ? : string
+   *      color   ? : string
+   *    }
+   * }} [info]
+   * @returns {string}
+   */
   function generateTabInfo(info) {
     // console.log(info.tabId, info);
     const timerStr =
@@ -49,17 +64,83 @@ import  { tgs }                   from './tgs.js';
     return html;
   }
 
+  async function promiseWithTimeout(promise, ms, ret) {
+    let timeoutId;
+
+    const timeoutPromise = new Promise((resolve) => {
+      timeoutId = setTimeout(() => {
+        resolve(ret);
+      }, ms);
+    });
+
+    return Promise.race([promise, timeoutPromise])
+      .finally(() => { clearTimeout(timeoutId); });
+  }
+
+  async function getDebugInfo(tabId, callback) {
+
+    const alarm = await chrome.alarms.get(String(tabId));
+    const tab   = await chrome.tabs.get(tabId);
+
+    const info  = {
+      windowId  : tab.windowId,
+      tabId     : tab.id,
+      groupId   : tab.groupId,
+      status    : gsUtils.STATUS_UNKNOWN,
+      timerUp   : alarm ? alarm.scheduledTime : '-',
+    };
+
+    if (chrome.runtime.lastError) {
+      gsUtils.error(tabId, chrome.runtime.lastError);
+      callback(info);
+      return;
+    }
+
+    if (gsUtils.isNormalTab(tab, true)) {
+      gsUtils.highlight(tab.id, 'getDebugInfo', tab.url);
+      gsMessages.sendRequestInfoToContentScript(tab.id, ( error, tabInfo ) => {
+        gsUtils.highlight(tab.id, 'getDebugInfo callback', tab.url);
+        // if (error) {
+        //   gsUtils.warning(tab.id, 'tgs', 'getDebugInfo', 'Failed to getDebugInfo', error);
+        // }
+        if (tabInfo) {
+          tgs.calculateTabStatus(tab, tabInfo.status, (status) => {
+            info.status = status;
+            // callback(info);
+          });
+        }
+        // else {
+        // }
+        callback(info);
+      });
+    }
+    else {
+      tgs.calculateTabStatus(tab, null, (status) => {
+        info.status = status;
+        callback(info);
+      });
+    }
+  }
+
   async function fetchInfo() {
     const tabs = await gsChrome.tabsQuery();
     const debugInfoPromises = [];
     for (const [i, curTab] of tabs.entries()) {
       currentTabs[tabs[i].id] = tabs[i];
       debugInfoPromises.push(
-        new Promise((resolve) =>
-          tgs.getDebugInfo(curTab.id, (info) => {
-            info.tab = curTab;
-            resolve(info);
-          })
+        promiseWithTimeout(
+          new Promise((resolve) =>
+            getDebugInfo(curTab.id, (info) => {
+              info.tab = curTab;
+              resolve(info);
+            })
+          ), 500, {
+            windowId  : curTab.windowId,
+            tabId     : curTab.id,
+            groupId   : curTab.groupId,
+            status    : gsUtils.STATUS_UNKNOWN,
+            tab       : curTab,
+          }
         )
       );
     }

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -1,3 +1,4 @@
+// @ts-check
 import  { gsChrome }              from './gsChrome.js';
 import  { gsFavicon }             from './gsFavicon.js';
 import  { gsMessages }            from './gsMessages.js';
@@ -6,7 +7,6 @@ import  { gsUtils }               from './gsUtils.js';
 import  { tgs }                   from './tgs.js';
 
 (() => {
-  'use strict';
 
   const currentTabs   = {};
   const browser       = navigator.userAgent.match(/Chrome\/.*Edg\//i) ? 'edge' : 'chrome';
@@ -28,27 +28,27 @@ import  { tgs }                   from './tgs.js';
    * @returns {string}
    */
   function generateTabInfo(info) {
-    // console.log(info.tabId, info);
+    // gsUtils.log('generateTabInfo', info?.tabId, info);
     const timerStr =
-      info && info.timerUp && info && info.timerUp !== '-'
+      info?.timerUp && info?.timerUp !== '-'
         // ? new Date(info.timerUp).toLocaleString()
         ? Math.round((new Date(info.timerUp).valueOf() - new Date().valueOf()) / 1000)
         : '-';
     let   html        = '';
-    const windowId    = info && info.windowId ? info.windowId : '?';
-    const tabId       = info && info.tabId ? info.tabId : '?';
-    const tabIndex    = info && info.tab ? info.tab.index : '?';
-    const tabTitle    = info && info.tab ? gsUtils.htmlEncode(info.tab.title) : '?';
+    const windowId    = info?.windowId        ?? '?';
+    const tabId       = info?.tabId           ?? '?';
+    const tabIndex    = info?.tab?.index      ?? '?';
+    const tabTitle    = info?.tab ? gsUtils.htmlEncode(info.tab.title) : '?';
     const tabTimer    = timerStr;
-    const tabStatus   = info ? info.status : '?';
-    const groupName   = info && info.group ? info.group.title : '';
+    const tabStatus   = info?.status          ?? '?';
+    const groupName   = info?.group?.title    ?? '';
 
     // const groupId     = info && info.groupId ? info.groupId : '?';
-    const groupColor  = info && info.group ? info.group.color : '';
+    const groupColor  = info?.group?.color    ?? '';
     const groupSpan   = groupName ? `<span class="group ${browser} ${groupColor}">${groupName}</span>` : '';
 
-    let   favicon   = info && info.tab ? info.tab.favIconUrl : '';
-    favicon   = favicon && favicon.indexOf('data') === 0 ? favicon : gsFavicon.getChromeFavIconUrl(info.tab.url);
+    let   favicon     = info?.tab?.favIconUrl ?? '';
+    favicon   = favicon.startsWith('data') ? favicon : gsFavicon.getChromeFavIconUrl(info?.tab?.url ?? '');
 
     html += '<tr>';
     html += `<td>${windowId}</td>`;
@@ -144,40 +144,44 @@ import  { tgs }                   from './tgs.js';
         )
       );
     }
+    const debugInfos = await Promise.all(debugInfoPromises);
 
     const tabGroupsMap = await gsChrome.tabGroupsMap();
-
     const rows = [];
-    const debugInfos = await Promise.all(debugInfoPromises);
     for (const debugInfo of debugInfos) {
       debugInfo.group = tabGroupsMap[debugInfo.groupId];
       rows.push(generateTabInfo(debugInfo));
     }
     const tableEl = document.getElementById('gsProfilerBody');
-    tableEl.innerHTML = rows.join('\n');
+    if (tableEl) {
+      tableEl.innerHTML = rows.join('\n');
+    }
   }
 
   async function addFlagHtml(elementId, getterFn, setterFn) {
-    const val = await getterFn();
-    document.getElementById(elementId).innerHTML = val;
-    document.getElementById(elementId).onclick = (event) => {
-      const newVal = !val;
-      setterFn(newVal);
-      document.getElementById(elementId).innerHTML = newVal;
-    };
+    const val   = await getterFn();
+    const elem  = document.getElementById(elementId);
+    if (elem) {
+      elem.innerHTML = val;
+      elem.onclick = (event) => {
+        const newVal = !val;
+        setterFn(newVal);
+        elem.innerHTML = String(newVal);
+      };
+    }
   }
 
-  gsUtils.documentReadyAndLocalisedAsPromised(window).then(async function() {
+  gsUtils.documentReadyAndLocalisedAsPromised(window).then(async () => {
 
     addFlagHtml(
       'toggleDebugInfo',
-      () => gsUtils.isDebugInfo(),
-      newVal => gsUtils.setDebugInfo(newVal)
+      ()        => gsUtils.isDebugInfo(),
+      (newVal)  => gsUtils.setDebugInfo(newVal)
     );
     addFlagHtml(
       'toggleDebugError',
-      () => gsUtils.isDebugError(),
-      newVal => gsUtils.setDebugError(newVal)
+      ()        => gsUtils.isDebugError(),
+      (newVal)  => gsUtils.setDebugError(newVal)
     );
     addFlagHtml(
       'toggleDiscardInPlaceOfSuspend',
@@ -185,30 +189,36 @@ import  { tgs }                   from './tgs.js';
       async (newVal)  => {  await gsStorage.setOptionAndSync(gsStorage.DISCARD_IN_PLACE_OF_SUSPEND, newVal); }
     );
 
-    document.getElementById('claimSuspendedTabs').onclick = async function(e) {
-      const tabs = await gsChrome.tabsQuery();
-      for (const tab of tabs) {
-        if (
-          gsUtils.isSuspendedTab(tab, true) &&
-          tab.url.indexOf(chrome.runtime.id) < 0
-        ) {
-          const newUrl = tab.url.replace( gsUtils.getRootUrl(tab.url), chrome.runtime.id );
-          await gsChrome.tabsUpdate(tab.id, { url: newUrl });
+    const claim   = document.getElementById('claimSuspendedTabs');
+    if (claim) {
+      claim.onclick = async function(e) {
+        const tabs  = await gsChrome.tabsQuery();
+        for (const tab of tabs) {
+          if (
+            gsUtils.isSuspendedTab(tab, true) &&
+            !(tab.url?.includes(chrome.runtime.id))
+          ) {
+            const newUrl = tab.url?.replace( gsUtils.getRootUrl(tab.url), chrome.runtime.id );
+            await gsChrome.tabsUpdate(tab.id, { url: newUrl });
+          }
         }
-      }
+      };
+    }
+
+    const extUrl  = `chrome://extensions/?id=${chrome.runtime.id}`;
+    const bgPage  = document.getElementById('backgroundPage');
+    if (bgPage) {
+      bgPage.setAttribute('href', extUrl);
+      bgPage.onclick = function() {
+        chrome.tabs.create({ url: extUrl });
+      };
+    }
+
+    window.onfocus = async () => {
+      await fetchInfo();
     };
 
-    var extensionsUrl = `chrome://extensions/?id=${chrome.runtime.id}`;
-    document.getElementById('backgroundPage').setAttribute('href', extensionsUrl);
-    document.getElementById('backgroundPage').onclick = function() {
-      chrome.tabs.create({ url: extensionsUrl });
-    };
-
-    window.onfocus = () => {
-      fetchInfo();
-    };
-
-    fetchInfo();
+    await fetchInfo();
 
   });
 

--- a/src/js/gsFavicon.js
+++ b/src/js/gsFavicon.js
@@ -114,11 +114,12 @@ export const gsFavicon = (() => {
   /**
    * @param   { string }  url
    * @param   { string }  tabFavIconUrl
+   * @param   { boolean } fCacheOnly
    * @param   { boolean } fRecursion
    * @returns { Promise< FavIconMeta | undefined > }
    */
-  async function getFaviconMetaForUrl(url, tabFavIconUrl, fRecursion = false) {
-    gsUtils.log('gsFavicon', 'getFaviconMetaForUrl', url, tabFavIconUrl);
+  async function getFaviconMetaForUrl(url, tabFavIconUrl, fCacheOnly = false, fRecursion = false) {
+    gsUtils.log('gsFavicon', 'getFaviconMetaForUrl', url, tabFavIconUrl, fCacheOnly, fRecursion);
 
     let faviconMeta = await getFaviconMetaFromCache(url);
     if (faviconMeta) {
@@ -126,6 +127,10 @@ export const gsFavicon = (() => {
       return faviconMeta;
     }
     gsUtils.log('gsFavicon', 'getFaviconMetaForUrl', 'No cached favicon', url);
+
+    if (fCacheOnly) {
+      return;
+    }
 
     // Else try to build from chrome's favicon cache
     faviconMeta = await buildFaviconMetaFromChrome(url);
@@ -152,7 +157,7 @@ export const gsFavicon = (() => {
 
     if (!fRecursion && fullUrl && rootUrl && fullUrl != rootUrl) {
       gsUtils.log('gsFavicon', 'Trying root hostname', fullUrl, rootUrl);
-      faviconMeta = await getFaviconMetaForUrl(rootUrl, tabFavIconUrl, true);
+      faviconMeta = await getFaviconMetaForUrl(rootUrl, tabFavIconUrl, fCacheOnly, true);
       if (faviconMeta) {
         gsUtils.log('gsFavicon', 'Built faviconMeta from root hostname', faviconMeta);
         await saveFaviconMetaToCache(url, faviconMeta);
@@ -164,10 +169,11 @@ export const gsFavicon = (() => {
 
   /**
    * @param   { chrome.tabs.Tab } tab
+   * @param   { boolean }         fCacheOnly
    * @returns { Promise< FavIconMeta > }
    */
-  async function getFaviconMeta(tab) {
-    gsUtils.log('gsFavicon', 'getFaviconMeta', tab.url);
+  async function getFaviconMeta(tab, fCacheOnly = false) {
+    gsUtils.log('gsFavicon', 'getFaviconMeta', tab.url, fCacheOnly);
 
     if (!tab.url || gsUtils.isFileTab(tab)) {
       return _defaultChromeFaviconMeta;
@@ -181,7 +187,7 @@ export const gsFavicon = (() => {
       originalUrl = gsUtils.getOriginalUrl(tab.url);
     }
 
-    const faviconMeta = await getFaviconMetaForUrl(originalUrl, tabFavIconUrl);
+    const faviconMeta = await getFaviconMetaForUrl(originalUrl, tabFavIconUrl, fCacheOnly);
     if (faviconMeta) {
       return faviconMeta;
     }

--- a/src/js/gsUtils.js
+++ b/src/js/gsUtils.js
@@ -181,7 +181,12 @@ export const gsUtils = {
       return false;
     }
     const url = gsUtils.getTabUrl(tab);
-    // NOTE: suspended urls start with "chrome" (chrome-extension://), so we first check isSuspendedTab above
+    // chrome-extension:// pages (TMS own pages or other extensions) cannot receive
+    // content scripts and must never be suspended — isBrowserInternalURL misses them
+    // because its regex matches "chrome:" but not "chrome-extension:".
+    if (url?.startsWith(`${chrome.runtime.getURL('').split(':')[0]}://`)) {
+      return true;
+    }
     return ( this.isBrowserInternalURL(url) || gsUtils.isBlockedFileTab(tab) );
   },
 

--- a/src/js/historyItems.js
+++ b/src/js/historyItems.js
@@ -1,19 +1,14 @@
+// @ts-check
 import  { gsFavicon }             from './gsFavicon.js';
 import  { gsSession }             from './gsSession.js';
 import  { gsUtils }               from './gsUtils.js';
 
 export const historyItems = (() => {
-  'use strict';
 
   async function createSessionHtml(session, showLinks) {
     session.windows = session.windows || [];
 
-    const sessionType =
-      session.sessionId === (await gsSession.getSessionId())
-        ? 'current'
-        : session.name
-        ? 'saved'
-        : 'recent';
+    const sessionType = session.sessionId === (await gsSession.getSessionId()) ? 'current' : session.name ? 'saved' : 'recent';
     const winCnt = session.windows.length;
     const tabCnt = session.windows.reduce(function(a, b) { return a + b.tabs.length; }, 0);
 
@@ -91,7 +86,7 @@ export const historyItems = (() => {
 
     const listHover = createEl( 'span', { class: 'itemHover removeLink' }, '\u274C\uFE0E');
 
-    const faviconMeta = await gsFavicon.getFaviconMeta(tab);
+    const faviconMeta = await gsFavicon.getFaviconMeta(tab, true);
     const favIconUrl = faviconMeta.normalisedDataUrl;
     const listImg = createEl('img', { src: favIconUrl, height: '16px', width: '16px' });
     const listLink = createEl('a', { class: 'historyLink', href: tab.url, target: '_blank' }, tab.title && tab.title.length > 1 ? tab.title : tab.url);

--- a/src/js/tgs.js
+++ b/src/js/tgs.js
@@ -1010,49 +1010,6 @@ export const tgs = (function() {
     return gsStorage.saveStorage('session', 'gsIsCharging', value);
   }
 
-  async function getDebugInfo(tabId, callback) {
-
-    const alarm = await chrome.alarms.get(String(tabId));
-    const tab   = await chrome.tabs.get(tabId);
-
-    const info  = {
-      windowId  : tab.windowId,
-      tabId     : tab.id,
-      groupId   : tab.groupId,
-      status    : gsUtils.STATUS_UNKNOWN,
-      timerUp   : alarm ? alarm.scheduledTime : '-',
-    };
-
-    if (chrome.runtime.lastError) {
-      gsUtils.error(tabId, chrome.runtime.lastError);
-      callback(info);
-      return;
-    }
-
-    if (gsUtils.isNormalTab(tab, true)) {
-      gsMessages.sendRequestInfoToContentScript(tab.id, ( error, tabInfo ) => {
-        // if (error) {
-        //   gsUtils.warning(tab.id, 'tgs', 'getDebugInfo', 'Failed to getDebugInfo', error);
-        // }
-        if (tabInfo) {
-          calculateTabStatus(tab, tabInfo.status, (status) => {
-            info.status = status;
-            callback(info);
-          });
-        }
-        else {
-          callback(info);
-        }
-      });
-    }
-    else {
-      calculateTabStatus(tab, null, (status) => {
-        info.status = status;
-        callback(info);
-      });
-    }
-  }
-
   function getContentScriptStatus(tabId, knownContentScriptStatus) {
     return new Promise((resolve) => {
       if (knownContentScriptStatus) {
@@ -1348,7 +1305,6 @@ export const tgs = (function() {
     initialiseTabContentScript,
     buildContextMenu,
     getActiveTabStatus,
-    getDebugInfo,
     calculateTabStatus,
 
     setIconStatus,


### PR DESCRIPTION
- Prevent extension tabs from being suspended #378 
- Fix Session (history) page to prevent long delays when favicons are not cached for old pages #379 
- Clean up the Debug page, and prevent timeouts for tabs within closed/collapsed Tab Groups

Notes:
A previous code fix to deal with "special" pages across all the different Chromium browsers inadvertently allowed TMS to suspend extension pages from other extensions.  This release adds a specific check for extension pages instead of the old method that relied on "chrome" to start the URL.

If Chrome cleans up its own favicon cache, and the favicon is also not withing the TMS cache, the Session / History page will show a default document icon.  That's by design now, because Chrome default CSP will not allow us to fetch favicons on our extension pages.
