### PR TITLE
Add option to preserve YouTube playback position

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -293,6 +293,9 @@
   "html_options_suspended_append_url_to_title_tooltip_line2": {
     "message": "This allows finding suspended tabs by hostname using Chrome's \"Search Tabs\" (Ctrl+Shift+A)."
   },
+  "html_options_suspended_add_youtube_timestamp": {
+    "message": "Preserve YouTube playback position when suspending"
+  },
   "html_options_other_title": {
     "message": "General"
   },

--- a/src/js/gsStorage.js
+++ b/src/js/gsStorage.js
@@ -43,6 +43,7 @@ export const gsStorage = {
   LOG_BUFFER                    : 'gsLogBuffer',
 
   APPEND_URL_TO_TITLE           : 'gsAppendUrlToTitle',
+  ADD_YOUTUBE_TIMESTAMP         : 'gsAddYouTubeTimestamp',
 
   noop: function() {},
 
@@ -76,6 +77,7 @@ export const gsStorage = {
     defaults[gsStorage.AUTO_BACKUP_TIME] = '09:00';
     defaults[gsStorage.AUTO_BACKUP_MAX_FILES] = 10;
     defaults[gsStorage.APPEND_URL_TO_TITLE] = true;
+    defaults[gsStorage.ADD_YOUTUBE_TIMESTAMP] = true;
 
     return defaults;
   },

--- a/src/js/gsTabSuspendManager.js
+++ b/src/js/gsTabSuspendManager.js
@@ -351,13 +351,17 @@ export const gsTabSuspendManager = (function() {
     });
   }
 
-  function generateUrlWithYouTubeTimestamp(tab) {
-    return new Promise(resolve => {
-      if (tab.url.indexOf('https://www.youtube.com/watch') < 0) {
-        resolve(tab.url);
-        return;
-      }
+  async function generateUrlWithYouTubeTimestamp(tab) {
+    if (!tab.url.includes('https://www.youtube.com/watch')) {
+      return tab.url;
+    }
 
+    const addYouTubeTimestamp = await gsStorage.getOption(gsStorage.ADD_YOUTUBE_TIMESTAMP);
+    if (!addYouTubeTimestamp) {
+      return tab.url;
+    }
+
+    return new Promise(resolve => {
       gsMessages.executeCodeOnTab(
         tab.id,
         [], // args for injection

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -14,6 +14,7 @@ import  { gsUtils }               from './gsUtils.js';
     claimByDefault: gsStorage.CLAIM_BY_DEFAULT,
     discardAfterSuspend: gsStorage.DISCARD_AFTER_SUSPEND,
     appendUrlToTitle:    gsStorage.APPEND_URL_TO_TITLE,
+    addYouTubeTimestamp: gsStorage.ADD_YOUTUBE_TIMESTAMP,
     dontSuspendPinned: gsStorage.IGNORE_PINNED,
     dontSuspendForms: gsStorage.IGNORE_FORMS,
     dontSuspendAudio: gsStorage.IGNORE_AUDIO,

--- a/src/options.html
+++ b/src/options.html
@@ -254,6 +254,11 @@ __MSG_html_options_suspended_append_url_to_title_tooltip_line2__">
         </span>
       </div>
       <div class="formRow">
+        <input type="checkbox" id="addYouTubeTimestamp" class="option" />
+        <label for="addYouTubeTimestamp" class="cbLabel"
+               data-i18n="__MSG_html_options_suspended_add_youtube_timestamp__"></label>
+      </div>
+      <div class="formRow">
         <input type="checkbox" id="unsuspendOnFocus" class="option" />
         <label for="unsuspendOnFocus" class="cbLabel" data-i18n="__MSG_html_options_suspend_automatically_unsuspend__"></label>
       </div>


### PR DESCRIPTION
- YouTube timestamps were previously always appended.
- The new setting allows disabling this behavior.
- It defaults to enabled, preserving existing behavior.
- Missing settings are migrated through the existing defaults mechanism.
- I've tested both enabled and disabled behavior.

Solves #284