### PR TITLE
fix(manifest): declare file:// as optional host permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Entries under "Unreleased" live on a feature branch until merged into `master`.
 
 ### Fixed
 - **Suspended tabs kept the default TMS favicon after a browser restart until clicked** (`background.js`, #397): the startup checks that repair favicons/titles on every suspended tab (`gsSession.runStartupChecks`) only ran from the service worker `activate` event (install/update only) and `chrome.runtime.onStartup`, which some Chromium builds (notably Brave) never fire after a normal restart — leaving suspended tabs stuck with the generic icon until manually focused. Added a fallback that checks a `chrome.storage.session` sentinel (cleared at the browser-session boundary) on every service worker wake and runs the startup checks once if it's missing, regardless of whether `onStartup` fired. Thanks @pbc-commits for the investigation and root-cause writeup.
+- **"Allow access to file URLs" toggle missing on every Chromium browser** (`manifest.json`, #393, #416, #267): Chrome only shows this toggle on an extension's details page when the manifest declares `file://` host access; TMS's `host_permissions` only ever listed `http://*/*`/`https://*/*`, so the toggle was invisible everywhere (confirmed on both fresh Chrome and Brave installs, not a Brave-specific quirk as first assumed). Added `"file:///*"` to a new `optional_host_permissions`, same on-demand pattern as `downloads`/`identity`, no access is granted until the user explicitly flips the toggle.
 
 ## [9.0.1] — 2026-08-04
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,6 +18,9 @@
     "downloads",
     "identity"
   ],
+  "optional_host_permissions": [
+    "file:///*"
+  ],
   "oauth2": {
     "client_id": "630779328171-1ijjbqo2n5k675q4rdp3q55fjuk0dnhh.apps.googleusercontent.com",
     "scopes": [


### PR DESCRIPTION
## Summary
- Chrome only shows the "Allow access to file URLs" toggle on an extension's details page when the manifest declares intent to access `file://` URLs.
- TMS's `host_permissions` only ever listed `http://*/*` / `https://*/*`, so the toggle was invisible on every Chromium browser (confirmed on a fresh Chrome install and on Brave, not a Brave-specific quirk as first assumed).
- Adds `"file:///*"` to a new `optional_host_permissions`, same on-demand pattern as `downloads`/`identity`. No access is granted until the user explicitly enables the toggle.

Closes #393, #416, #267.

## Test plan
- [x] Load unpacked with this manifest, confirm "Allow access to file URLs" appears on the extension's details page in both Chrome and Brave
- [x] Confirm no access is granted by default (toggle off until user flips it)
- [x] Confirm the existing "Local files cannot be suspended" / Enable flow (`permissions.html`) still works end-to-end once the toggle is on

Not merging yet, holding this open until 9.0.2 goes live.