### PR TITLE
feat(debug): add "Clear favicon cache" action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Entries under "Unreleased" live on a feature branch until merged into `master`.
 ## [Unreleased]
 
 ### Added
+- **"Clear favicon cache" debug action** (`debug.html`, `debug.js`, `gsIndexedDb.js`, #395): the debug page can now wipe every cached favicon (`gsFaviconMeta` in IndexedDB) in one click. Favicons are rebuilt from Chrome's own cache the next time each tab is suspended, useful when a suspended tab keeps showing a stale or wrong icon after the site's own favicon has changed.
 - **About page: debug link highlighted in its own callout box** (`about.html`, `style.css`, `icons.svg`): the debugging link was a plain paragraph, easy to miss among the other links. Gave it a bordered callout with a wrench icon, matching the card/box language used elsewhere in the extension's UI.
 
 ### Fixed

--- a/src/debug.html
+++ b/src/debug.html
@@ -70,6 +70,18 @@
 
         <div class="debugOptionCard">
           <div class="debugOptionCardHeader">
+            <svg class="debugOptionIcon" aria-hidden="true"><use href="img/icons.svg#rotate-cw"/></svg>
+            <span class="debugOptionLabel">favicon cache</span>
+            <a id='clearFaviconCache' href='#' class="debugToggle">clear cache</a>
+          </div>
+          <p class="debugOptionDesc">
+            Wipes every cached favicon (<code>gsFaviconMeta</code> in IndexedDB). Favicons are rebuilt from Chrome's own cache the next time each tab is suspended.
+            Use if a suspended tab keeps showing a stale or wrong icon after the site's own favicon has changed.
+          </p>
+        </div>
+
+        <div class="debugOptionCard">
+          <div class="debugOptionCardHeader">
             <svg class="debugOptionIcon" aria-hidden="true"><use href="img/icons.svg#rss"/></svg>
             <span class="debugOptionLabel">news feed</span>
             <a id='forceNewsFeedRefresh' href='#' class="debugToggle">force refresh</a>

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -2,6 +2,7 @@
 import  { gsBackup }              from './gsBackup.js';
 import  { gsChrome }              from './gsChrome.js';
 import  { gsFavicon }             from './gsFavicon.js';
+import  { gsIndexedDb }           from './gsIndexedDb.js';
 import  { gsMessages }            from './gsMessages.js';
 import  { gsNewsFeed }            from './gsNewsFeed.js';
 import  { gsStorage }             from './gsStorage.js';
@@ -334,6 +335,16 @@ import  { tgs }                   from './tgs.js';
     }
   }
 
+  // ── Favicon cache ─────────────────────────────────────────────────────────────────────────
+
+  async function onClearFaviconCache(e) {
+    e.preventDefault();
+    const link = document.getElementById('clearFaviconCache');
+    await gsIndexedDb.clearFaviconMeta();
+    link.textContent = 'cleared!';
+    setTimeout(() => { link.textContent = 'clear cache'; }, 2000);
+  }
+
   // ── Layout ─────────────────────────────────────────────────────────────────────────────────
 
   function equalizeCardHeights() {
@@ -358,6 +369,7 @@ import  { tgs }                   from './tgs.js';
     document.getElementById('toggleCaptureLogs').addEventListener('click', onToggleCaptureLogs);
     document.getElementById('toggleDiscardInPlaceOfSuspend').addEventListener('click', onToggleDiscard);
     document.getElementById('claimSuspendedTabs').addEventListener('click', onClaimSuspendedTabs);
+    document.getElementById('clearFaviconCache').addEventListener('click', onClearFaviconCache);
     const isStoreInstall = !!chrome.runtime.getManifest().update_url;
     const feedRefreshLink = document.getElementById('forceNewsFeedRefresh');
     const simulateUnreadLink = document.getElementById('simulateUnread');

--- a/src/js/gsIndexedDb.js
+++ b/src/js/gsIndexedDb.js
@@ -136,6 +136,11 @@ export const gsIndexedDb = {
     return null;
   },
 
+  clearFaviconMeta: async function() {
+    const db = await gsIndexedDb.getDb();
+    await db.clear(gsIndexedDb.DB_FAVICON_META);
+  },
+
   updateSession: async function(session) {
     try {
       const db = await gsIndexedDb.getDb();


### PR DESCRIPTION
## Summary
- Adds a "Clear favicon cache" action to the debug page (`debug.html`, `debug.js`)
- Wipes every cached favicon (`gsFaviconMeta` object store) via new `gsIndexedDb.clearFaviconMeta()`
- Favicons are rebuilt from Chrome's own cache the next time each tab is suspended

Closes #395

## Test plan
- [x] Open `debug.html`, click "clear cache" next to favicon cache, confirm button flashes "cleared!" then reverts
- [x] Verify `gsFaviconMeta` IndexedDB store is empty after clearing
- [x] Suspend a tab afterwards and confirm favicon is correctly rebuilt